### PR TITLE
Add I18N support to Select choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,16 @@ Additional options that are available:
 
 * `include_blank`: If true or a string, includes a blank option in the dropdown (with the string as its text).
 * `prettify`: If true, passes all choices through [`titleize`](http://api.rubyonrails.org/classes/String.html#method-i-titleize) before displaying them (in all views). If a lambda, that lambda is used instead of `titleize`.
+* `i18n`: If true, passes all choices through [`i18n`](https://github.com/svenfuchs/i18n) before displaying them (in all views). 
+
+If both `prettify` and `i18n` are specified then `prettify` takes
+precedence.
 
 ## Todo
 
 Some ideas for possible enhancements:
 
-1. Support i18n instead of prettify
-2. Be more magic with enum types and reflect the choices
+1. Be more magic with enum types and reflect the choices
 
 ## Contributing
 

--- a/lib/administrate/field/select_basic.rb
+++ b/lib/administrate/field/select_basic.rb
@@ -24,7 +24,7 @@ module Administrate
       def convert item, raw: false
         return [prettify(item), item] if prettify? && !raw
         return prettify(item) if prettify? && raw
-        return internationalise(item) if i18n?
+        return internationalise(item, raw: raw) if i18n?
         return item
       end
   
@@ -44,7 +44,8 @@ module Administrate
         end
       end
 
-      def internationalise item
+      def internationalise item, raw: false
+        return I18n.t(item) if raw
         item.respond_to?(:each) ? [I18n.t(item.first), item.last] : [I18n.t(item), item]
       end
     end

--- a/lib/administrate/field/select_basic.rb
+++ b/lib/administrate/field/select_basic.rb
@@ -12,7 +12,7 @@ module Administrate
       end
   
       def to_s
-        prettify? ? prettify(data) : data
+        convert(data, raw: true)
       end
   
       def include_blank
@@ -21,8 +21,9 @@ module Administrate
     
       private
 
-      def convert item
-        return [prettify(item), item] if prettify?
+      def convert item, raw: false
+        return [prettify(item), item] if prettify? && !raw
+        return prettify(item) if prettify? && raw
         return internationalise(item) if i18n?
         return item
       end

--- a/lib/administrate/field/select_basic.rb
+++ b/lib/administrate/field/select_basic.rb
@@ -23,7 +23,7 @@ module Administrate
 
       def convert item
         return [prettify(item), item] if prettify?
-        return [I18n.t(item), item] if i18n?
+        return internationalise(item) if i18n?
         return item
       end
   
@@ -41,6 +41,10 @@ module Administrate
         else
           str.titleize
         end
+      end
+
+      def internationalise item
+        item.respond_to?(:each) ? [I18n.t(item.first), item.last] : [I18n.t(item), item]
       end
     end
   end

--- a/lib/administrate/field/select_basic.rb
+++ b/lib/administrate/field/select_basic.rb
@@ -8,8 +8,7 @@ module Administrate
       end      
       
       def choices
-        options.fetch(:choices, []).
-          map { |o| prettify? ? [prettify(o), o] : o }
+        options.fetch(:choices, []).map { |o| convert(o) }
       end
   
       def to_s
@@ -21,9 +20,19 @@ module Administrate
       end
     
       private
+
+      def convert item
+        return [prettify(item), item] if prettify?
+        return [I18n.t(item), item] if i18n?
+        return item
+      end
   
       def prettify?
         !!options[:prettify]
+      end
+
+      def i18n?
+        !!options[:i18n]
       end
   
       def prettify(str)

--- a/lib/administrate/field/select_basic.rb
+++ b/lib/administrate/field/select_basic.rb
@@ -5,29 +5,37 @@ module Administrate
   module Field
     class SelectBasic < Base
       class Engine < ::Rails::Engine
-      end      
-      
+      end
+
       def choices
-        options.fetch(:choices, []).map { |o| convert(o) }
+        options.fetch(:choices, []).map { |o| convert_to_array(o) }
       end
-  
+
       def to_s
-        convert(data, raw: true)
+        convert(data)
       end
-  
+
       def include_blank
         options.fetch(:include_blank, false)
       end
-    
+
       private
 
-      def convert item, raw: false
-        return [prettify(item), item] if prettify? && !raw
-        return prettify(item) if prettify? && raw
-        return internationalise(item, raw: raw) if i18n?
+      def convert_to_array item
+        return item if do_not_modify_contents?
+        item.respond_to?(:each) ? [convert(item.first), item.last] : [convert(item), item]
+      end
+
+      def convert item
+        return prettify(item) if prettify?
+        return internationalise(item) if i18n?
         return item
       end
-  
+
+      def do_not_modify_contents?
+        !(prettify? || i18n?)
+      end
+
       def prettify?
         !!options[:prettify]
       end
@@ -35,18 +43,17 @@ module Administrate
       def i18n?
         !!options[:i18n]
       end
-  
-      def prettify(str)
-        if options[:prettify].respond_to? :call
-          options[:prettify].call(str)
-        else
-          str.titleize
-        end
+
+      def callable_prettify?
+        options[:prettify].respond_to? :call
       end
 
-      def internationalise item, raw: false
-        return I18n.t(item) if raw
-        item.respond_to?(:each) ? [I18n.t(item.first), item.last] : [I18n.t(item), item]
+      def prettify(str)
+        callable_prettify? ? options[:prettify].call(str) : str.titleize
+      end
+
+      def internationalise item
+        return I18n.t(item)
       end
     end
   end

--- a/spec/administrate/field/select_basic_spec.rb
+++ b/spec/administrate/field/select_basic_spec.rb
@@ -40,6 +40,16 @@ describe Administrate::Field::SelectBasic do
         expect(subject.choices).to eq([[3, 'foo'], [3, 'bar'], [4, 'bazz']])
       end
     end
+    context '1D :choices with i18n=true' do
+      let(:options) { { choices: %w{foo bar baz}, i18n: true } }
+      it 'returns 1d choices with translated 1st element' do
+        allow(I18n).to receive(:t).with('foo').and_return('FOO')
+        allow(I18n).to receive(:t).with('bar').and_return('BAR')
+        allow(I18n).to receive(:t).with('baz').and_return('BAZ')
+
+        expect(subject.choices).to eq([['FOO', 'foo'], ['BAR', 'bar'], ['BAZ', 'baz']])
+      end
+    end
   end
   
   describe '#to_s' do

--- a/spec/administrate/field/select_basic_spec.rb
+++ b/spec/administrate/field/select_basic_spec.rb
@@ -79,6 +79,13 @@ describe Administrate::Field::SelectBasic do
         expect(subject.to_s).to eq(6)
       end
     end    
+    context 'i18n=true' do
+      let(:options) { { i18n: true } }
+      it "translates data" do 
+        allow(I18n).to receive(:t).with('wibble').and_return('Das Wieble')
+        expect(subject.to_s).to eq('Das Wieble')
+      end
+    end
   end
   
   describe '#include_blank' do

--- a/spec/administrate/field/select_basic_spec.rb
+++ b/spec/administrate/field/select_basic_spec.rb
@@ -50,6 +50,15 @@ describe Administrate::Field::SelectBasic do
         expect(subject.choices).to eq([['FOO', 'foo'], ['BAR', 'bar'], ['BAZ', 'baz']])
       end
     end
+    context '2D :choices with i18n=true' do
+      let(:options) { { choices: [['foo', 0], ['bar', 1]], i18n: true } }
+      it 'returns 2d choices with translated 1st element and unadulterated 2nd element' do
+        allow(I18n).to receive(:t).with('foo').and_return('FOO')
+        allow(I18n).to receive(:t).with('bar').and_return('BAR')
+
+        expect(subject.choices).to eq([['FOO', 0], ['BAR', 1]])
+      end
+    end
   end
   
   describe '#to_s' do

--- a/spec/administrate/field/select_basic_spec.rb
+++ b/spec/administrate/field/select_basic_spec.rb
@@ -15,27 +15,27 @@ describe Administrate::Field::SelectBasic do
         expect(subject.choices).to eq([])
       end
     end
-    context '1D :choices without prettify' do
+    context '1D :choices with no modification options' do
       let(:options) { { choices: %w{foo bar baz} } }
       it 'returns the choices verbatim' do
         expect(subject.choices).to eq(%w{foo bar baz})
       end
     end
-    context '2D :choices' do
+    context '2D :choices with no modification options' do
       let(:choices) { [['foo', 'BAR'], ['baz', 'QUX']] }
       let(:options) { { choices: choices } }
       it 'returns the choices verbatim' do
         expect(subject.choices).to eq(choices)
       end
     end
-    context '1D :choices with prettify=true' do
-      let(:options) { { choices: %w{foo bar baz}, prettify: true } }
+    context '1D :choices with prettify=true (overriding i18n settings)' do
+      let(:options) { { choices: %w{foo bar baz}, prettify: true, i18n: true } }
       it 'returns 2d choices with titleized 1st element' do
         expect(subject.choices).to eq([['Foo', 'foo'], ['Bar', 'bar'], ['Baz', 'baz']])
       end
     end
-    context '1D :choices with prettify=lambda' do
-      let(:options) { { choices: %w{foo bar bazz}, prettify: ->(x) {x.length} } }
+    context '1D :choices with prettify=lambda (overriding i18n settings)' do
+      let(:options) { { choices: %w{foo bar bazz}, prettify: ->(x) {x.length}, i18n: true } }
       it 'returns 2d choices with lambda called on 1st element' do
         expect(subject.choices).to eq([[3, 'foo'], [3, 'bar'], [4, 'bazz']])
       end


### PR DESCRIPTION
Hi Rich,

I've added a new `i18n: true` option to the select field type.  If true (and prettify is not selected) then it feeds the choices through the standard I18N processor.  

Either 1D (`%w{option_1 option_2} => [I18n.t('option_1'), I18n.t('option_2')]`) or, more usefully 2D (`[['model_name.option_1', 'this'], ['model_name.option_2', 'that']] => [[I18n.t('model_name.option_1'), 'this'], [I18n.t('model_name.option_2'), 'that']]`)

I've not touched to_s yet, although I'll look at that when I get time. 

Cheers

Baz.
